### PR TITLE
Modified the dependencies section to notify the need to install Tkinter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Or manually:
 pip install numpy scipy matplotlib librosa textual
 ```
 
+Tkinter is not distributed through PyPI and must be installed in other ways:
+
+Debian:
+```bash
+sudo apt install python3-tk
+```
+MacOS:
+```bash
+brew install python-tk
+```
+
 ---
 
 ## Installation


### PR DESCRIPTION
Tkinter, one of the dependencies of MIRLAB, is not installable via pip and is a required dependency, therefore it must be notified in the appropriate section of the README.